### PR TITLE
Owlot/fix pay api

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+[{*.md,*.mdx,LICENSE*}]
+# double whitespace at end of line
+# denotes a line break in Markdown
+indent_size = off
+trim_trailing_whitespace = false
+[{Makefile*,*.mk,*.sh}]
+indent_style = tab
+[{*.ts,*.tsx,*.html,*.yml,*.yaml,*.yaml.tftpl,*.toml,*.json,*.tf,*.hcl,*.js}]
+indent_size = 2

--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
+API_URL=http://srv
+
 RPC_MAINNET=http://eth1:8545
 BN_MAINNET=http://eth2:5052
 
@@ -6,5 +8,9 @@ BN_HOLESKY=http://eth2:5053
 
 # When running the dev stack, we need a way to have act communicate with our eth2 client.
 # If this client is running on the same machine, but in a different docker network,
-# you can set that network name in the variable below.
-VALIDATOR_DOCKER_NETWORK=rocketpool_net
+# you can set that network name in the variable below. eg. 'rocketpool_net'
+VALIDATOR_DOCKER_NETWORK=none # 'none' can be used to omit internal connectivity.
+
+# When you want the fee server to be exposed through the vrun-db provided proxy service,
+# you need to add the fee service to the 'vrun-proxy' network for connectivity
+PROXY_DOCKER_NETWORK=vrun-proxy

--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,5 @@
 API_URL=http://srv
+LOG_LEVEL=info
 
 RPC_MAINNET=http://eth1:8545
 BN_MAINNET=http://eth2:5052

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ name: vrun-fee
 
 networks:
   proxy:
-    name: ${PROXY_DOCKER_NETWORK:-vrun-db_proxy}
+    name: ${PROXY_DOCKER_NETWORK:-vrun-proxy}
     external: true
   validator:
     name: ${VALIDATOR_DOCKER_NETWORK:-vrun-db_default}
@@ -16,7 +16,16 @@ configs:
     file: signing.key
 
 services:
-  fee:
+  api-dev:
+    extends: api
+    container_name: ${COMPOSE_PROJECT_NAME}-dev
+    profiles:
+      - dev
+    networks:
+      - validator
+      - proxy
+
+  api:
     container_name: ${COMPOSE_PROJECT_NAME}
     user: ${FEE_USER:-fee}:${FEE_USER:-fee}
     env_file:
@@ -28,11 +37,12 @@ services:
         - FEE_USER=${FEE_USER:-fee}
       tags:
         - vrun-fee:local-dev
+    profiles:
+      - api
     ports:
       - 8082:${FEE_LISTEN_PORT:-8080}
     networks:
       - validator
-      - proxy
     configs:
       - source: dot-env
         target: /.env
@@ -40,7 +50,7 @@ services:
         target: /usr/share/fee/signing.key
     labels:
       - "traefik.enable=true"
-      - "traefik.http.services.vrun-fee.loadbalancer.server.scheme=http"
-      - "traefik.http.routers.vrun-fee.rule=PathPrefix(`/fee/`)"
-      - "traefik.http.routers.vrun-fee.middlewares=vrun-fee-strip-prefixes"
-      - "traefik.http.middlewares.vrun-fee-strip-prefixes.stripprefix.prefixes=/fee"
+      - "traefik.http.services.vrun-fee-api.loadbalancer.server.scheme=http"
+      - "traefik.http.routers.vrun-fee-api.rule=PathPrefix(`/fee/`)"
+      - "traefik.http.routers.vrun-fee-api.middlewares=vrun-fee-api-strip-prefixes"
+      - "traefik.http.middlewares.vrun-fee-api-strip-prefixes.stripprefix.prefixes=/fee"

--- a/local-dev.md
+++ b/local-dev.md
@@ -26,12 +26,12 @@ This service requires the vrun-db local environment to be up and running as well
 
 ### Start the service in the background
 ```bash
-docker compose up -d
+docker compose --profile dev up -d
 ```
 
 ### Follow logs
 ```bash
-docker compose logs -f
+docker compose --profile dev logs -f
 ```
 
 ### Rebuild image after code changes


### PR DESCRIPTION
## Pay API bug fixes (bc6cfa90e6e0845865b70dbb4c509cd7af681c97)

- Fixes `CreditAccount` type mismatch with `db` (reason vs comment)
- Make sure `ChainId` is passed as an integer and not a string in `eip712DomainForChain`
- Variable `tokenChainId` was expected to be set on multiple lines in the `/pay` API code. This variable was named `txChainId` instead. The variable name has been changed to `tokenChainId` now.
- The `creditAccountSignature` variable was set to a promise because of a missing `await` keyword.
- The wrong object was being posted to the `/credit` API of `db`. The object keys have been fixed now.

## New logging feature (4a2d2f3c5fba172a4e93921e5cd1a4807dac2483)
Creates an override for the `console.debug`, `console.info`, `console.warn` and `console.error` functions; prefixing the log lines with a timestamp and the log severity.
Based on the LOG_LEVEL environment variable (default `info`), the lines will be printed to stdout or not shown at all, providing an easier way to debug the API when needed.
Additional debug lines have been added to the code.

## Docker Compose dev profile (bc6cfa90e6e0845865b70dbb4c509cd7af681c97)
Adds the option to run fee within the proxy network (`dev` profile) or not (`api` profile).